### PR TITLE
Fix python3 configparser compatibility

### DIFF
--- a/pythonx/notmuch_abook.py
+++ b/pythonx/notmuch_abook.py
@@ -104,7 +104,7 @@ class NotMuchConfig(object):
             config_file = os.environ.get('NOTMUCH_CONFIG', '~/.notmuch-config')
 
         # set a default for ignorefile
-        self.config = configparser.ConfigParser({'ignorefile': None})
+        self.config = configparser.ConfigParser({'ignorefile': ''})
         self.config.read(os.path.expanduser(config_file))
 
     def get(self, section, key):


### PR DESCRIPTION
This change fixes configparser usage where option values must be
strings.