### PR TITLE
Use Python 3 if Vim was build with -python +python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Notmuch Addressbook manager for vim
 DEPENDENCES
 -----------
 
-* notmuch with python bindings
+* notmuch with python or python3 bindings
 
 INSTALL
 -------


### PR DESCRIPTION
https://github.com/guyzmo/notmuch-abook/pull/35
---
As the title says, this allows you to use notmuch-abook with a Vim build without Python 2 but with Python 3 support. Unfortunately, I don't know how to support both Python 2 and 3 without the code duplication.

